### PR TITLE
fix: Fix boot_menu script

### DIFF
--- a/boot_menu.yml
+++ b/boot_menu.yml
@@ -5,7 +5,6 @@ ublue_variants:
       - label: lazuli
         info: Lazuli image
 
-ublue_variants:
   - label: jerbmega/lazuli-vrr
     ks: /kickstart/ublue-os.ks
     flavors:

--- a/boot_menu.yml
+++ b/boot_menu.yml
@@ -1,21 +1,25 @@
 ublue_variants:
   - label: jerbmega/lazuli
     ks: /kickstart/ublue-os.ks
-    subvariants:
-      - label: Lazuli image
-      - label: Lazuli image with VRR
-        suffix: -vrr
     flavors:
       - label: lazuli
-        info: Standard OS image
+        info: Lazuli image
+
+ublue_variants:
+  - label: jerbmega/lazuli-vrr
+    ks: /kickstart/ublue-os.ks
+    flavors:
+      - label: lazuli-vrr
+        info: Lazuli image + VRR
 
   - label: jerbmega/lazuli-nvidia
-    ks: /kickstart/ublue-os-nvidia.ks
-    subvariants:
-      - label: Lazuli + Nvidia image
-      - label: Lazuli + Nvidia image with VRR
-        suffix: -vrr    
+    ks: /kickstart/ublue-os-nvidia.ks  
     flavors:
       - label: lazuli-nvidia
-        info: Standard OS image + Nvidia drivers  
+        info: Lazuli image + Nvidia drivers
 
+  - label: jerbmega/lazuli-nvidia-vrr
+    ks: /kickstart/ublue-os-nvidia.ks  
+    flavors:
+      - label: lazuli-nvidia-vrr
+        info: Lazuli image + Nvidia drivers + VRR          


### PR DESCRIPTION
Unfortunately, startingpoint's release-iso script wrongly uses "subvariants" line, and it puts it like this in installer:

lazuli:38-vrr

instead of:

lazuli-vrr:38

To avoid those issues, use classic labeling instead.